### PR TITLE
fix build

### DIFF
--- a/inc/ddp_types.h
+++ b/inc/ddp_types.h
@@ -233,6 +233,5 @@ typedef enum _adapter_parameter_t{
 
 /* Types defining specific function pointers for generating output*/
 typedef ddp_status_t (*ddp_output_function_t)(list_t*, ddp_status_value_t, char*);
-ddp_output_function_t ddp_func_print_adapter_list;
 
 #endif

--- a/src/ddp.c
+++ b/src/ddp.c
@@ -38,6 +38,8 @@ extern uint16_t            i40e_supported_devices_size;
 extern supported_devices_t ice_supported_devices[];
 extern uint16_t            ice_supported_devices_size;
 
+ddp_output_function_t ddp_func_print_adapter_list;
+
 ddp_status_t
 validate_output_status(ddp_status_t status)
 {


### PR DESCRIPTION
Getting "multiple definition of `ddp_func_print_adapter_list';" error
since the global variable defined in the header file which included by
multiple .c files, causing the global variable exist in multiple object
file making linker unhappy.

Signed-off-by: Ferruh Yigit <ferruh.yigit@intel.com>